### PR TITLE
Add oob_channel to associate response

### DIFF
--- a/draft.xml
+++ b/draft.xml
@@ -172,6 +172,10 @@ Content-Type: application/json
               REQUIRED.  Authenticator type that was associated with the user's
               account.
             </t>
+            <t hangText='oob_channel'>
+              <vspace />
+              REQUIRED.  The out-of-band channel to use.
+            </t>
             <t hangText='barcode_uri'>
               <vspace />
               OPTIONAL. URI to be rendered as a barcode which can be scanned


### PR DESCRIPTION
Why?

The server must select one of the supported types passed by the client, it is important for the client to be able to know which one was selected